### PR TITLE
Campaign membership

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -16,6 +16,7 @@ class CampaignsController < ApplicationController
     @campaign = @user.campaigns.new(campaign_params)
 
      if @campaign.save
+        CampaignMembership.create!(user_id: @user.id, campaign_id: @campaign.id)
         redirect_to campaign_path(@campaign), notice: "The campaign begins!"
      else
         render "new"

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -13,7 +13,7 @@ class CampaignsController < ApplicationController
 
   def create
     @user = User.find(current_user)
-    @campaign = @user.campaigns.new(campaign_params)
+    @campaign = Campaign.new(campaign_params)
 
      if @campaign.save
         CampaignMembership.create!(user_id: @user.id, campaign_id: @campaign.id)
@@ -50,6 +50,6 @@ class CampaignsController < ApplicationController
   private
 
   def campaign_params
-    params.require(:campaign).permit(:name, :description, :simulator_url, :next_session)
+    params.require(:campaign).permit(:name, :description, :simulator_url, :next_session, :user_id)
   end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,5 +1,5 @@
 class Campaign < ActiveRecord::Base
-  
+    
   has_many :campaign_memberships
   has_many :users, through: :campaign_memberships
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,3 +1,5 @@
 class Campaign < ActiveRecord::Base
-  belongs_to :user
+  
+  has_many :campaign_memberships
+  has_many :users, through: :campaign_memberships
 end

--- a/app/models/campaign_membership.rb
+++ b/app/models/campaign_membership.rb
@@ -1,0 +1,6 @@
+class CampaignMembership < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :campaign
+
+  validates_uniqueness_of :user_id, scope: :campaign_id
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ActiveRecord::Base
-
   has_many :xml_files
   has_many :pathfinder_decks
-  has_many :campaigns
+  has_many :campaign_memberships
+  has_many :campaigns, through: :campaign_memberships
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/views/campaigns/new.html.erb
+++ b/app/views/campaigns/new.html.erb
@@ -6,6 +6,7 @@
       <%= f.input :description %>
       <%= f.input :simulator_url, label: "Simulator URL" %>
       <%= f.input :next_session, html5: true, input_html: {value: Date.today} %>
+      <%= f.hidden_field :user_id, value: @user.id %>
       <%= f.button :submit, "Begin the Campaign!", class: "btn-lg submit-button btn-primary" %>
     <% end %>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'kyle.sponheim@gmail.com'
+  config.mailer_sender = 'accounts@campaignmanager.xyz'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/db/migrate/20170704014757_create_campaign_memberships.rb
+++ b/db/migrate/20170704014757_create_campaign_memberships.rb
@@ -1,0 +1,10 @@
+class CreateCampaignMemberships < ActiveRecord::Migration
+  def change
+    create_table :campaign_memberships do |t|
+      t.integer :user_id
+      t.integer :campaign_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170703194220) do
+ActiveRecord::Schema.define(version: 20170704014757) do
+
+  create_table "campaign_memberships", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "campaign_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "campaigns", force: :cascade do |t|
     t.string   "name"

--- a/spec/factories/campaign_memberships.rb
+++ b/spec/factories/campaign_memberships.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :campaign_membership do
+    user_id 1
+    campaign_id 1
+  end
+end

--- a/spec/models/campaign_membership_spec.rb
+++ b/spec/models/campaign_membership_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CampaignMembership, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR moves the association between Users and Campaigns to a join table, CampaignMemberships. This allows many users to have campaigns and will eventually allow a User to leave a campaign without ruining it for everyone else. 