### PR TITLE
various template fixes

### DIFF
--- a/app/models/xml_file.rb
+++ b/app/models/xml_file.rb
@@ -7,7 +7,6 @@ class XmlFile < ActiveRecord::Base
   after_create :create_pathfinder_deck
 
   def create_pathfinder_deck
-    binding.pry
     CreatePathfinderDeckJob.perform_later(self.user, self)
   end
 end

--- a/app/views/campaigns/new.html.erb
+++ b/app/views/campaigns/new.html.erb
@@ -7,7 +7,7 @@
       <%= f.input :simulator_url, label: "Simulator URL" %>
       <%= f.input :next_session, html5: true, input_html: {value: Date.today} %>
       <%= f.hidden_field :user_id, value: @user.id %>
-      <%= f.button :submit, "Begin the Campaign!", class: "btn-lg submit-button btn-primary" %>
+      <div class="row"><%= f.button :submit, "Begin the Campaign!", class: "btn-lg submit-button btn-primary" %></div>
     <% end %>
     </div>
   </div>

--- a/app/views/xml_files/create.html.erb
+++ b/app/views/xml_files/create.html.erb
@@ -1,2 +1,0 @@
-<h1>XmlFiles#create</h1>
-<p>Find me in app/views/xml_files/create.html.erb</p>

--- a/app/views/xml_files/destroy.html.erb
+++ b/app/views/xml_files/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>XmlFiles#destroy</h1>
-<p>Find me in app/views/xml_files/destroy.html.erb</p>

--- a/app/views/xml_files/index.html.erb
+++ b/app/views/xml_files/index.html.erb
@@ -1,4 +1,15 @@
+<h3>New HeroLab File</h3>
+
+<div class = "well">
+   <%= simple_form_for :xml_file, html: { multipart: true, class: 'form-horizontal' } do |f| %>
+      <%= f.input :name, as: :string %>
+      <div class="row"><%= f.file_field :attachment %></div>
+      <div class="row" style="padding-top:15px;"><%= f.submit "Upload", class: "btn btn-primary" %></div>
+   <% end %>
+</div>
+
 <h3>My HeroLab Files</h3>
+
 <table class="table table-bordered table-striped" data-turbolinks="false">
    <thead>
       <tr>
@@ -26,5 +37,3 @@
    </tbody>
    
 </table>
-
-<%= link_to "New XML File", new_xml_file_path(@user), class: "btn btn-primary" %>


### PR DESCRIPTION
This PR removes two unused templates and moves the new XmlFile form to the Xml Index page. The end result is that XmlFiles can be created and deleted on the same page, because a user should not have to visit a new page just to upload a file.