### PR TITLE
Campaign reminders

### DIFF
--- a/app/jobs/campaign_reminder_job.rb
+++ b/app/jobs/campaign_reminder_job.rb
@@ -1,0 +1,9 @@
+class CampaignReminderJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    Campaign.playing_today.find_each do |campaign|
+      campaign.users.each { |user| CampaignReminderMailer.campaign_reminder_email(user, campaign).deliver_later }
+    end
+  end
+end

--- a/app/jobs/campaign_reminder_job.rb
+++ b/app/jobs/campaign_reminder_job.rb
@@ -3,7 +3,7 @@ class CampaignReminderJob < ActiveJob::Base
 
   def perform
     Campaign.playing_today.find_each do |campaign|
-      campaign.users.each { |user| CampaignReminderMailer.campaign_reminder_email(user, campaign).deliver_later }
+      campaign.users.find_each { |user| CampaignReminderMailer.campaign_reminder_email(user, campaign).deliver_later }
     end
   end
 end

--- a/app/mailers/campaign_reminder_mailer.rb
+++ b/app/mailers/campaign_reminder_mailer.rb
@@ -1,0 +1,9 @@
+class CampaignReminderMailer < ApplicationMailer
+  default from: "reminders@campaignmanager.xyz"
+
+  def campaign_reminder_email(recipient, campaign)
+    @recipient = recipient
+    @campaign = campaign
+    mail(to: @recipient.email, subject: "Reminder: #{@campaign.name} has a Session Today")
+  end
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -2,4 +2,6 @@ class Campaign < ActiveRecord::Base
   has_many :campaign_memberships, dependent: :destroy
   has_many :campaign_invitations, dependent: :destroy
   has_many :users, through: :campaign_memberships
+
+  scope :playing_today, -> { where(next_session: Date.today) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ActiveRecord::Base
   has_many :campaigns, through: :campaign_memberships, dependent: :destroy
   has_many :campaign_invitations, foreign_key: :recipient_email, dependent: :destroy
 
+  scope :subscribed_to, -> (campaign) { includes(:campaign_memberships).where(campaign_memberships: { receive_notifications: :true, campaign_id: campaign.id }) }
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/campaign_reminder_mailer/campaign_reminder_email.html.erb
+++ b/app/views/campaign_reminder_mailer/campaign_reminder_email.html.erb
@@ -1,0 +1,5 @@
+Hi <%= @recipient.email %>, 
+
+<p>This is a friendly reminder that <b><%= @campaign.name %></b> has a session today.<p>
+
+<p><%= link_to("View your campaign and start taking notes.", campaign_url(@campaign)) %></p>

--- a/db/migrate/20170719233355_add_recieve_notifications_to_campaign_memberships.rb
+++ b/db/migrate/20170719233355_add_recieve_notifications_to_campaign_memberships.rb
@@ -1,0 +1,5 @@
+class AddRecieveNotificationsToCampaignMemberships < ActiveRecord::Migration
+  def change
+    add_column :campaign_memberships, :receive_notifications, :boolean, default: :true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170710051335) do
+ActiveRecord::Schema.define(version: 20170719233355) do
 
   create_table "campaign_invitations", force: :cascade do |t|
     t.integer  "sender_id"
@@ -23,21 +23,12 @@ ActiveRecord::Schema.define(version: 20170710051335) do
     t.datetime "updated_at",      null: false
   end
 
-  create_table "campaign_membership_invitations", force: :cascade do |t|
-    t.string   "email"
-    t.integer  "campaign_id"
-    t.integer  "sender_id"
-    t.integer  "recipient_id"
-    t.string   "token"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
-  end
-
   create_table "campaign_memberships", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "campaign_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.boolean  "receive_notifications", default: true
   end
 
   create_table "campaign_notes", force: :cascade do |t|
@@ -75,6 +66,16 @@ ActiveRecord::Schema.define(version: 20170710051335) do
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority"
+
+  create_table "movies", force: :cascade do |t|
+    t.string   "title"
+    t.string   "rating"
+    t.decimal  "total_gross"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.text     "description"
+    t.date     "released_on"
+  end
 
   create_table "pathfinder_decks", force: :cascade do |t|
     t.string  "name"

--- a/spec/jobs/campaign_reminder_job_spec.rb
+++ b/spec/jobs/campaign_reminder_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CampaignReminderJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/campaign_reminder_mailer_spec.rb
+++ b/spec/mailers/campaign_reminder_mailer_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe CampaignReminderMailer, type: :mailer do
+  describe "campaign_reminder_email" do
+    let(:mail) { CampaignReminderMailer.campaign_reminder_email }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Campaign reminder email")
+      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Hi")
+    end
+  end
+
+end

--- a/spec/mailers/previews/campaign_reminder_mailer_preview.rb
+++ b/spec/mailers/previews/campaign_reminder_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/campaign_reminder_mailer
+class CampaignReminderMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/campaign_reminder_mailer/campaign_reminder_email
+  def campaign_reminder_email
+    CampaignReminderMailer.campaign_reminder_email
+  end
+
+end


### PR DESCRIPTION
This PR adds the concept of a campaign or session reminder and a job to send the reminder email. Users need to be reminded of their upcoming sessions on the morning of the session. 

This adds a new scope to Campaigns to find Campaigns where the next_session is today. The job uses this new scope to iterate through Campaigns that are playing today and triggers a reminder email to be delivered to each of the campaign's users in the background.

To-Do:

1. Add the heroku scheduler file.
2. Allow Users to turn campaign reminders on/off. This may require a new column on Campaigns.
3. Make sure there are no campaigns in production with a next_session in the future.